### PR TITLE
prevent renaming non-fat-jar to *-plain.jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -167,6 +167,7 @@ compileJava.dependsOn jaxb
 
 jar {
     enabled = true
+    archiveClassifier = ''
 }
 
 bootJar {


### PR DESCRIPTION
Seit 2.5.0 wird das *.jar-File zu *-plain.jar umgenannt. Das muss verhindert werden, damit das Maven-Repo funktioniert.