### PR TITLE
Use Base64 class from JDK

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     //compile ('ch.so.agi.oereb:pdf4oereb:1.0.+') {
     //	exclude group: 'org.slf4j', module: 'slf4j-simple'
     //}
-    compile group: 'org.postgresql', name: 'postgresql', version: '42.2.6' // add as compileOnly, so that eclipse sees it
+    compile group: 'org.postgresql', name: 'postgresql'
     compile	group: 'javax.xml.bind',name:'jaxb-api', version:'2.3.1'
     compile	group: 'com.sun.xml.bind',name:'jaxb-core', version:'2.3.0.1'
     compile	group: 'com.sun.xml.bind',name:'jaxb-impl', version:'2.3.2'

--- a/src/main/java/ch/ehi/oereb/webservice/OerebController.java
+++ b/src/main/java/ch/ehi/oereb/webservice/OerebController.java
@@ -27,7 +27,7 @@ import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
 
-import org.postgresql.util.Base64;
+import java.util.Base64;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -223,7 +223,7 @@ public class OerebController {
     private String oerebPlanForLandregister;
     
     
-    private static byte[] minimalImage=Base64.decode("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==");
+    private static byte[] minimalImage=Base64.getDecoder().decode("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==");
 
     @GetMapping("/")
     public ResponseEntity<String>  ping() {


### PR DESCRIPTION
In neueren Postgresql-JDBC Jars ist die postgresql base64 Klasse nicht mehr vorhanden. Das ist ein Problem, weil Spring Boot 2.7.1 auf einer solchen neueren Version basiert. Dass das noch funkionierte ist wohl eher Zufall.