### PR TITLE
Set content type for xml output in extract controllers

### DIFF
--- a/src/main/java/ch/ehi/oereb/webservice/OerebController.java
+++ b/src/main/java/ch/ehi/oereb/webservice/OerebController.java
@@ -543,7 +543,10 @@ public class OerebController {
         if(format.equals(PARAM_CONST_PDF)) {
             return createExtractAsPdf(parcel, responseEle);
         }
-        return new ResponseEntity<GetExtractByIdResponse>(responseEle,HttpStatus.OK);
+        
+        HttpHeaders responseHeaders = new HttpHeaders();
+        responseHeaders.setContentType(MediaType.APPLICATION_XML);
+        return new ResponseEntity<GetExtractByIdResponse>(responseEle,responseHeaders,HttpStatus.OK);
     }
     private ResponseEntity<?> createExtractAsPdf(Grundstueck parcel, GetExtractByIdResponse responseEle) {
         java.io.File tmpFolder=new java.io.File(oerebTmpdir,TMP_FOLDER_PREFIX+Thread.currentThread().getId());
@@ -611,7 +614,10 @@ public class OerebController {
         if(format.equals(PARAM_CONST_PDF)) {
             return createExtractAsPdf(parcel, responseEle);
         }
-        return new ResponseEntity<GetExtractByIdResponse>(responseEle,HttpStatus.OK);
+        
+        HttpHeaders responseHeaders = new HttpHeaders();
+        responseHeaders.setContentType(MediaType.APPLICATION_XML);
+        return new ResponseEntity<GetExtractByIdResponse>(responseEle,responseHeaders,HttpStatus.OK);
     }    
     private ResponseEntity<?>  getExtractWithGeometryByNumber(String format,String identdn,String number,String lang,String topics,String withImagesParam,int dpi) {
         if(!format.equals(PARAM_CONST_XML) && !format.equals(PARAM_CONST_PDF)) {
@@ -642,7 +648,9 @@ public class OerebController {
         if(format.equals(PARAM_CONST_PDF)) {
             return createExtractAsPdf(parcel, responseEle);
         }
-        return new ResponseEntity<GetExtractByIdResponse>(responseEle,HttpStatus.OK);
+        HttpHeaders responseHeaders = new HttpHeaders();
+        responseHeaders.setContentType(MediaType.APPLICATION_XML);
+        return new ResponseEntity<GetExtractByIdResponse>(responseEle,responseHeaders,HttpStatus.OK);
     }    
     private ResponseEntity<?> getExtractRedirect(String egridParam, String identdn, String number) {
         String egrid=verifyEgrid(egridParam, identdn, number);
@@ -684,7 +692,9 @@ public class OerebController {
         if(format.equals(PARAM_CONST_PDF)) {
             return createExtractAsPdf(parcel, responseEle);
         }
-        return new ResponseEntity<GetExtractByIdResponse>(responseEle,HttpStatus.OK);
+        HttpHeaders responseHeaders = new HttpHeaders();
+        responseHeaders.setContentType(MediaType.APPLICATION_XML);
+        return new ResponseEntity<GetExtractByIdResponse>(responseEle,responseHeaders,HttpStatus.OK);
     }    
     @GetMapping("/capabilities/{format}")
     public @ResponseBody  GetCapabilitiesResponse getCapabilities(@PathVariable String format) {


### PR DESCRIPTION
Setzt explizit einen Content-Type für den XML-Output in Extract-Controller. GetEGRID hat bereits funktioniert ohne, da in diesem Fall der Standard Message Converter verwendet wird. Beim PDF-Output wird bereits der Content-Typ explizit gesetzt.

Geprüft mit folgenden curl-Befehlen:

```

curl -v "http://localhost:8080/extract/xml/?EGRID=CH410606327377"
curl -v "http://localhost:8080/extract/xml/?EGRID=CH410606327377&GEOMETRY=true"
curl -v "http://localhost:8080/extract/xml/?IDENTDN=SO0200002546&NUMBER=4586"
curl -v "http://localhost:8080/extract/xml/?IDENTDN=SO0200002546&NUMBER=4586&GEOMETRY=true"

curl -v "http://localhost:8080/getegrid/xml/?EN=2595820,1226924"
curl -v "http://localhost:8080/getegrid/xml/?GEOMETRY=true&EN=2595820,1226924"
curl -v "http://localhost:8080/getegrid/xml/?IDENTDN=SO0200002546&NUMBER=4586"
curl -v "http://localhost:8080/getegrid/xml/?IDENTDN=SO0200002546&NUMBER=4586&GEOMETRY=true"
```