### PR TITLE
Make only necessary wms requests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     
     compile group: 'com.vividsolutions', name: 'jts-core', version: '1.14.0'
     compile 'commons-io:commons-io:2.6'
-    implementation ('io.github.sogis:pdf4oereb:2.0.119') {
+    implementation ('io.github.sogis:pdf4oereb:2.0.120') {
     //implementation ('io.github.sogis:app:2.0.47') {
         exclude group: 'org.slf4j', module: 'slf4j-simple'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     
     compile group: 'com.vividsolutions', name: 'jts-core', version: '1.14.0'
     compile 'commons-io:commons-io:2.6'
-    implementation ('io.github.sogis:pdf4oereb:2.0.120') {
+    implementation ('io.github.sogis:pdf4oereb:2.0.121') {
     //implementation ('io.github.sogis:app:2.0.47') {
         exclude group: 'org.slf4j', module: 'slf4j-simple'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -82,6 +82,7 @@ repositories {
     maven {
         url "http://jars.interlis.ch"
     }
+    maven { url "https://s01.oss.sonatype.org/service/local/repositories/releases/content/" }
 }
 
 def generatedXjcSources = "$buildDir/xjc/java"

--- a/src/main/java/ch/ehi/oereb/webservice/OerebController.java
+++ b/src/main/java/ch/ehi/oereb/webservice/OerebController.java
@@ -1026,6 +1026,11 @@ public class OerebController {
         }
         return ret;
     }
+    
+    private String getMultilingualUri(MultilingualUriType multilingualUri) {
+        return multilingualUri.getLocalisedText().get(0).getText();
+    }
+    
     private MultilingualUriType createMultilingualUri(Map<String, Object> baseData,String prefix) {
         MultilingualUriType ret=new MultilingualUriType();
         {
@@ -1518,15 +1523,8 @@ public class OerebController {
                         }
                         wmsUrl = getWmsUrl(bbox, wmsUrl,dpi);
                         map.setReferenceWMS(createMultilingualUri(wmsUrl));
-                        if(withImages) {
-                            try {
-                                byte wmsImage[]=getWmsImage(wmsUrl);
-                                map.setImage(createMultilingualBlob(wmsImage));
-                            } catch (IOException | URISyntaxException e) {
-                                logger.error("failed to get wms image",e);
-                                map.setImage(createMultilingualBlob(minimalImage));
-                            }
-                        }
+                        // Make WMS requests later, after figuring out which restrictions
+                        // are concerned.
                         double layerOpacity[]=new double[1];
                         Integer layerIndex=getLayerIndex(wmsUrl,layerOpacity);
                         if(layerIndex==null) {
@@ -1874,6 +1872,19 @@ public class OerebController {
                     map.getOtherLegend().add(legendEntries.get(entryId));
                 }
             }
+            
+            // wms requests
+            if(withImages) {
+                try {
+                    String wmsUrl = getMultilingualUri(map.getReferenceWMS());
+                    byte wmsImage[]=getWmsImage(wmsUrl);
+                    map.setImage(createMultilingualBlob(wmsImage));
+                } catch (IOException | URISyntaxException e) {
+                    logger.error("failed to get wms image",e);
+                    map.setImage(createMultilingualBlob(minimalImage));
+                }
+            }
+
             rests.add(rest);
         }        
         concernedTopicsList.addAll(concernedTopics);


### PR DESCRIPTION
WMS-Requests (für WITHIMAGES=true) werden für alle möglichen Restrictions gemacht. Die Prüfung, ob eine Restriction (die mit einer DB-Query ermittelt wurde) tatsächlich das Grundstück betrifft (und nicht bloss in der BBOX liegt), erfolgt später. 

Der Request wird nun später gemacht. Die Methode "getMultilingualUri" ist eventuell noch verbesserungswürdig.

Romedis Killergrundstück CH267808542786 dauert nun noch circa 35 Sekunden. Vorher gings minutenlang.

cc @romefi @vvmruder 